### PR TITLE
Strip whitespace in parse_requirements() function in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def parse_requirements(filename):
     requirements = []
     for line in open(filename):
         if line and not line.startswith("#"):
-            requirements.append(line)
+            requirements.append(line.strip())
     return requirements
 
 


### PR DESCRIPTION
The `install_requires` argument of setuptools.setup fails to properly
install python packages from pypi if the package names contain
whitespace. Strip the whitespace from `requirements.txt` which is read
by `setup.py`