### PR TITLE
Update E2Client to use e2t v1beta1 API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SHELL = bash -e -o pipefail
 .PHONY: test help
 
 # all files with extensions
-PYTHON_FILES      ?= $(wildcard onos-ric-sdk-py/*.py tests/*.py)
+PYTHON_FILES      ?= $(wildcard onos_ric_sdk_py/*.py tests/*.py)
 
 # tooling
 VIRTUALENV        ?= python3 -m venv

--- a/onos_ric_sdk_py/e2.py
+++ b/onos_ric_sdk_py/e2.py
@@ -159,7 +159,13 @@ class E2Client(e2.E2Client):
         stream = client.subscribe(headers=headers, subscription=subscription)
         return Subscription(subscription.id, stream)
 
-    async def unsubscribe(self, e2_node_id: str, subscription_id: str) -> None:
+    async def unsubscribe(  # type: ignore
+        self,
+        e2_node_id: str,
+        service_model_name: str,
+        service_model_version: str,
+        subscription_id: str,
+    ) -> None:
         client = SubscriptionServiceStub(self._e2t_channel)
         headers = RequestHeaders(
             app_id=self._app_id,

--- a/onos_ric_sdk_py/e2.py
+++ b/onos_ric_sdk_py/e2.py
@@ -159,8 +159,8 @@ class E2Client(e2.E2Client):
         stream = client.subscribe(headers=headers, subscription=subscription)
         return Subscription(subscription.id, stream)
 
-    async def unsubscribe(self, subscription_id: str) -> None:
-        raise NotImplementedError()
+    async def unsubscribe(self, e2_node_id: str, subscription_id: str) -> None:
+        client = SubscriptionServiceStub(self._e2t_channel)
 
     async def __aenter__(self) -> "E2Client":
         return self

--- a/onos_ric_sdk_py/e2.py
+++ b/onos_ric_sdk_py/e2.py
@@ -1,133 +1,40 @@
 # SPDX-FileCopyrightText: © 2021 Open Networking Foundation <support@opennetworking.org>
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
+from __future__ import absolute_import
+
 import ssl
+import os
 from typing import AsyncIterator, List, Optional, Tuple
 from uuid import uuid4
 
-import betterproto
 from aiomsa import e2, models
-from aiomsa.exceptions import E2ClientError
-from betterproto.grpc.util.async_channel import AsyncChannel
 from grpclib.client import Channel
-from onos_api.e2sub.endpoint import E2RegistryServiceStub
-from onos_api.e2sub.subscription import (
+from onos_api.e2t.admin import E2TAdminServiceStub
+from onos_api.e2t.e2.v1beta1 import (
     Action,
     ActionType,
-    E2SubscriptionServiceStub,
+    ControlMessage,
+    ControlServiceStub,
     Encoding,
     EventTrigger,
-    Payload,
-    ServiceModel as E2SubServiceModel,
-    Subscription as E2Subscription,
-    SubscriptionDetails,
+    RequestHeaders,
+    ServiceModel,
     SubsequentAction,
     SubsequentActionType,
+    Subscription,
+    SubscriptionServiceStub,
     TimeToWait,
 )
-from onos_api.e2sub.task import E2SubscriptionTaskServiceStub, EventType, Status
-from onos_api.e2t.admin import E2TAdminServiceStub
-from onos_api.e2t.e2 import (  # ResponseStatus,
-    ControlAckRequest,
-    E2TServiceStub,
-    EncodingType,
-    RequestHeader,
-    ServiceModel as E2TServiceModel,
-    StreamRequest,
-    StreamResponse,
-)
-
-
-class Subscription(e2.Subscription):
-    def __init__(
-        self,
-        subscription_id: str,
-        app_id: str,
-        e2sub_channel: Channel,
-        ssl_context: Optional[ssl.SSLContext],
-    ) -> None:
-        self._id = subscription_id
-        self._app_id = app_id
-        self._watch_task = asyncio.create_task(self._watch(e2sub_channel, ssl_context))
-        self._stream_lock = asyncio.Semaphore(0)
-        self._stream: Optional[AsyncIterator[StreamResponse]] = None
-
-    async def getone(self) -> Optional[Tuple[bytes, bytes]]:
-        # The lock blocks the subscription until its fully created
-        async with self._stream_lock:
-            if self._watch_task.done():
-                self._watch_task.result()
-
-            if self._stream is None:
-                return None
-            async for msg in self._stream:
-                return msg.indication_header, msg.indication_message
-            else:
-                return None
-
-    async def _watch(
-        self, e2sub_channel: Channel, ssl_context: Optional[ssl.SSLContext]
-    ) -> None:
-        endpoint_client = E2RegistryServiceStub(e2sub_channel)
-        task_client = E2SubscriptionTaskServiceStub(e2sub_channel)
-        prev_endpoint_id = None
-        async for response in task_client.watch_subscription_tasks(
-            subscription_id=self._id
-        ):
-            event = response.event
-            if event.task.subscription_id != self._id:
-                # Only interested in tasks related to this subscription
-                continue
-            if event.task.endpoint_id == prev_endpoint_id:
-                # Skip if the stream is already open for the associated E2 endpoint
-                continue
-            if event.task.lifecycle.status == Status.FAILED:
-                raise Exception(event.task.lifecycle.failure.message)
-
-            if event.type == EventType.NONE or event.type == EventType.CREATED:
-                termination = await endpoint_client.get_termination(
-                    id=event.task.endpoint_id
-                )
-                async with Channel(
-                    termination.endpoint.ip, termination.endpoint.port, ssl=ssl_context
-                ) as channel:
-                    e2t_client = E2TServiceStub(channel)
-                    requests: AsyncChannel = AsyncChannel()
-                    await requests.send_from(
-                        [
-                            StreamRequest(
-                                app_id=self._app_id,
-                                subscription_id=self._id,
-                            )
-                        ],
-                        close=True,
-                    )
-                    self._stream = e2t_client.stream(requests)
-                    self._stream_lock.release()
-            elif event.type == EventType.REMOVED:
-                # Take the lock until the stream has been recreated
-                await self._stream_lock.acquire()
-                self._stream = None
-
-    @property
-    def id(self) -> str:
-        return self._id
-
-    def __aiter__(self) -> "Subscription":
-        return self
-
-    async def __anext__(self) -> Optional[Tuple[bytes, bytes]]:
-        while True:
-            return await self.getone()
 
 
 class E2Client(e2.E2Client):
+    INSTANCE_ID = os.getenv("HOSTNAME", "")
+
     def __init__(
         self,
         app_id: str,
         e2t_endpoint: str,
-        e2sub_endpoint: str,
         ca_path: Optional[str] = None,
         cert_path: Optional[str] = None,
         key_path: Optional[str] = None,
@@ -144,9 +51,7 @@ class E2Client(e2.E2Client):
             self._ssl_context.check_hostname = not skip_verify
 
         e2t_ip, e2t_port = e2t_endpoint.rsplit(":", 1)
-        e2sub_ip, e2sub_port = e2sub_endpoint.rsplit(":", 1)
         self._e2t_channel = Channel(e2t_ip, int(e2t_port), ssl=self._ssl_context)
-        self._e2sub_channel = Channel(e2sub_ip, int(e2sub_port), ssl=self._ssl_context)
 
     async def list_nodes(self, oid: Optional[str] = None) -> List[models.E2Node]:
         nodes = []
@@ -181,88 +86,66 @@ class E2Client(e2.E2Client):
         message: bytes,
         control_ack_request: models.RICControlAckRequest,
     ) -> Optional[bytes]:
-        e2t_client = E2TServiceStub(self._e2t_channel)
-        request_header = RequestHeader(
-            encoding_type=EncodingType.PROTO,
-            service_model=E2TServiceModel(
+        client = ControlServiceStub(self._e2t_channel)
+        headers = RequestHeaders(
+            app_id=self._app_id,
+            instance_id=self.INSTANCE_ID,
+            node_id=e2_node_id,
+            service_model=ServiceModel(
                 name=service_model_name, version=service_model_version
             ),
+            encoding=Encoding.PROTO,
         )
 
-        control_response = await e2t_client.control(
-            header=request_header,
-            e2_node_id=e2_node_id,
-            control_header=header,
-            control_message=message,
-            control_ack_request=ControlAckRequest(control_ack_request),
+        outcome = await client.control(
+            headers=headers,
+            message=ControlMessage(header=header, payload=message),
         )
-        name, value = betterproto.which_one_of(control_response, "response")
-        if value is None:
-            raise E2ClientError("E2 control response is missing")
-        if name == "control_failure":
-            raise E2ClientError(f"Control failure ({value.cause}): {value.message}")
+        return outcome.payload
 
-        # The value of response is `control_acknowledge`
-        if control_ack_request == ControlAckRequest.NO_ACK:
-            return None
-        # TODO: Restore this when response_status is populated
-        # if control_response.header.response_status == ResponseStatus.FAILED:
-        #     pass
-        # elif control_response.header.response_status == ResponseStatus.REJECTED:
-        #     pass
-
-        return value.control_outcome
-
-    async def subscribe(
+    async def subscribe(  # type: ignore
         self,
         e2_node_id: str,
         service_model_name: str,
         service_model_version: str,
         trigger: bytes,
         actions: List[models.RICAction],
-    ) -> Subscription:
-        subscription_client = E2SubscriptionServiceStub(self._e2sub_channel)
-        subscription = E2Subscription(
-            id=str(uuid4()),
+    ) -> AsyncIterator[Tuple[bytes, bytes]]:
+        client = SubscriptionServiceStub(self._e2t_channel)
+        headers = RequestHeaders(
             app_id=self._app_id,
-            details=SubscriptionDetails(
-                e2_node_id=e2_node_id,
-                service_model=E2SubServiceModel(
-                    name=service_model_name, version=service_model_version
-                ),
-                event_trigger=EventTrigger(
-                    payload=Payload(encoding=Encoding.ENCODING_PROTO, data=trigger)
-                ),
+            instance_id=self.INSTANCE_ID,
+            node_id=e2_node_id,
+            service_model=ServiceModel(
+                name=service_model_name, version=service_model_version
             ),
+            encoding=Encoding.PROTO,
+        )
+        subscription = Subscription(
+            id=str(uuid4()),
+            event_trigger=EventTrigger(payload=trigger),
         )
         for a in actions:
             action = Action(id=a.id, type=ActionType(a.type))
             if a.definition is not None:
-                action.payload = Payload(
-                    encoding=Encoding.ENCODING_PROTO, data=a.definition
-                )
+                action.payload = a.definition
             if a.subsequent_action is not None:
                 action.subsequent_action = SubsequentAction(
                     type=SubsequentActionType(a.subsequent_action.type),
                     time_to_wait=TimeToWait(a.subsequent_action.time_to_wait),
                 )
-            subscription.details.actions.append(action)
+            subscription.actions.append(action)
 
-        await subscription_client.add_subscription(subscription=subscription)
-        return Subscription(
-            subscription.id,
-            self._app_id,
-            self._e2sub_channel,
-            self._ssl_context,
-        )
+        async for response in client.subscribe(
+            headers=headers, subscription=subscription
+        ):
+            yield response.indication.header, response.indication.payload
 
     async def unsubscribe(self, subscription_id: str) -> None:
-        subscription_client = E2SubscriptionServiceStub(self._e2sub_channel)
-        await subscription_client.remove_subscription(id=subscription_id)
+        raise NotImplementedError()
 
     async def __aenter__(self) -> "E2Client":
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         self._e2t_channel.close()
-        self._e2sub_channel.close()

--- a/onos_ric_sdk_py/e2.py
+++ b/onos_ric_sdk_py/e2.py
@@ -161,6 +161,17 @@ class E2Client(e2.E2Client):
 
     async def unsubscribe(self, e2_node_id: str, subscription_id: str) -> None:
         client = SubscriptionServiceStub(self._e2t_channel)
+        headers = RequestHeaders(
+            app_id=self._app_id,
+            instance_id=self.INSTANCE_ID,
+            node_id=e2_node_id,
+            service_model=ServiceModel(
+                name=service_model_name, version=service_model_version
+            ),
+            encoding=Encoding.PROTO,
+        )
+
+        await client.unsubscribe(headers=headers, subscription_id=subscription_id)
 
     async def __aenter__(self) -> "E2Client":
         return self

--- a/onos_ric_sdk_py/e2.py
+++ b/onos_ric_sdk_py/e2.py
@@ -45,7 +45,7 @@ class Subscription(e2.Subscription):
         async for response in self._stream:
             return response.indication.header, response.indication.payload
         else:
-            return None
+            raise StopAsyncIteration
 
 
 class E2Client(e2.E2Client):

--- a/onos_ric_sdk_py/e2.py
+++ b/onos_ric_sdk_py/e2.py
@@ -41,7 +41,7 @@ class Subscription(e2.Subscription):
     def __aiter__(self) -> "Subscription":
         return self
 
-    async def __anext__(self) -> Optional[Tuple[bytes, bytes]]:
+    async def __anext__(self) -> Tuple[bytes, bytes]:
         async for response in self._stream:
             return response.indication.header, response.indication.payload
         else:

--- a/onos_ric_sdk_py/e2.py
+++ b/onos_ric_sdk_py/e2.py
@@ -3,8 +3,8 @@
 
 from __future__ import absolute_import
 
-import ssl
 import os
+import ssl
 from typing import AsyncIterator, List, Optional, Tuple
 from uuid import uuid4
 
@@ -62,16 +62,16 @@ class E2Client(e2.E2Client):
     ) -> None:
         self._app_id = app_id
 
-        self._ssl_context = None
+        ssl_context = None
         if ca_path is not None and cert_path is not None and key_path is not None:
-            self._ssl_context = ssl.create_default_context(
+            ssl_context = ssl.create_default_context(
                 ssl.Purpose.SERVER_AUTH, cafile=ca_path
             )
-            self._ssl_context.load_cert_chain(certfile=cert_path, keyfile=key_path)
-            self._ssl_context.check_hostname = not skip_verify
+            ssl_context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+            ssl_context.check_hostname = not skip_verify
 
         e2t_ip, e2t_port = e2t_endpoint.rsplit(":", 1)
-        self._e2t_channel = Channel(e2t_ip, int(e2t_port), ssl=self._ssl_context)
+        self._e2t_channel = Channel(e2t_ip, int(e2t_port), ssl=ssl_context)
 
     async def list_nodes(self, oid: Optional[str] = None) -> List[models.E2Node]:
         nodes = []


### PR DESCRIPTION
`v1beta` of the E2T API drastically changes the way that the SDK `E2Client` can be implemented. Major changes include:

1. The `E2Client` can initiate subscriptions and directly to `onos-e2t` instead of having to interface with `onos-e2sub`. As such, the `onos-e2sub` argument to the constructor is removed entirely
2. The linter wasn't actually picking up on source code in the main project, so I updated the `Makefile`
3. `unsubscribe` is changed to raise a `NotImplementedError` until the `v1beta1` API supports removing subscriptions