### PR TITLE
Add **kwargs to client constructors

### DIFF
--- a/onos_ric_sdk_py/e2.py
+++ b/onos_ric_sdk_py/e2.py
@@ -57,6 +57,7 @@ class E2Client(aiomsa.abc.E2Client):
         cert_path: Optional[str] = None,
         key_path: Optional[str] = None,
         skip_verify: bool = True,
+        **kwargs: str,
     ) -> None:
         self._app_id = app_id
 

--- a/onos_ric_sdk_py/sdl.py
+++ b/onos_ric_sdk_py/sdl.py
@@ -30,6 +30,7 @@ class SDLClient(aiomsa.abc.SDLClient):
         cert_path: Optional[str] = None,
         key_path: Optional[str] = None,
         skip_verify: bool = True,
+        **kwargs: str,
     ) -> None:
         ssl_context = None
         if ca_path is not None and cert_path is not None and key_path is not None:


### PR DESCRIPTION
This lets us initialize all the clients from the same dictionary (even if some keys may not apply to each client)