### PR TITLE
use cell_global_id to find cell objects, update [set|get]_cell_data to support multiple ops per call

### DIFF
--- a/onos_ric_sdk_py/sdl.py
+++ b/onos_ric_sdk_py/sdl.py
@@ -214,7 +214,7 @@ class SDLClient(aiomsa.abc.SDLClient):
                 op_count += 1
 
         if op_count == 0:
-            return None
+            return
 
         try:
             await client.update(object=resp.object)

--- a/onos_ric_sdk_py/sdl.py
+++ b/onos_ric_sdk_py/sdl.py
@@ -164,7 +164,7 @@ class SDLClient(aiomsa.abc.SDLClient):
         except GRPCError as e:
             raise ClientRuntimeError() from e
 
-        data = []
+        data: List[Optional[bytes]] = []
         for k in keys:
             type_data = resp.object.aspects.get(k)
             if type_data is None:

--- a/onos_ric_sdk_py/sdl.py
+++ b/onos_ric_sdk_py/sdl.py
@@ -109,7 +109,9 @@ class SDLClient(aiomsa.abc.SDLClient):
         except GRPCError as e:
             raise ClientRuntimeError() from e
 
-    async def _get_cell_entity_id(self, e2_node_id: str, cell_global_id: str) -> Optional[str]:
+    async def _get_cell_entity_id(
+        self, e2_node_id: str, cell_global_id: str
+    ) -> Optional[str]:
         """
         given e2_node_id and cell_global_id, returns entity id
         returns None if cell_global_id is not found
@@ -206,7 +208,9 @@ class SDLClient(aiomsa.abc.SDLClient):
                     del resp.object.aspects[key]
                     op_count += 1
             else:
-                resp.object.aspects[key] = betterproto.lib.google.protobuf.Any(key, data)
+                resp.object.aspects[key] = betterproto.lib.google.protobuf.Any(
+                    key, data
+                )
                 op_count += 1
 
         if op_count == 0:


### PR DESCRIPTION
use cell_global_id rather than cell_object_id because cell_global_id is an actual identifier.
frequently use set and get with multiple properties(aspects), so it is cleaner and more efficient to combine them.